### PR TITLE
Use jai-imageio-core 1.3.0 instead of jai_imageio 1.1

### DIFF
--- a/dcm4che-imageio/pom.xml
+++ b/dcm4che-imageio/pom.xml
@@ -38,12 +38,20 @@
             <version>1.6.1</version>
             <scope>test</scope>
         </dependency>
+<!--
         <dependency>
             <groupId>com.sun.media</groupId>
             <artifactId>jai_imageio</artifactId>
             <version>1.1</version>
             <scope>provided</scope>
         </dependency>
+-->
+<dependency>
+    <groupId>com.github.jai-imageio</groupId>
+    <artifactId>jai-imageio-core</artifactId>
+    <version>1.3.0</version>
+</dependency>
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/dcm4che-imageio/src/main/java/org/dcm4che2/imageio/ItemParser.java
+++ b/dcm4che-imageio/src/main/java/org/dcm4che2/imageio/ItemParser.java
@@ -53,9 +53,9 @@ import org.dcm4che2.util.TagUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.sun.media.imageio.stream.SegmentedImageInputStream;
-import com.sun.media.imageio.stream.StreamSegment;
-import com.sun.media.imageio.stream.StreamSegmentMapper;
+import com.github.jaiimageio.stream.SegmentedImageInputStream;
+import com.github.jaiimageio.stream.StreamSegment;
+import com.github.jaiimageio.stream.StreamSegmentMapper;
 
 /**
  * @author Gunter Zeilinger <gunterze@gmail.com>

--- a/dcm4che-imageio/src/main/java/org/dcm4che2/imageioimpl/plugins/dcm/DicomImageReader.java
+++ b/dcm4che-imageio/src/main/java/org/dcm4che2/imageioimpl/plugins/dcm/DicomImageReader.java
@@ -89,8 +89,8 @@ import org.dcm4che2.util.ByteUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.sun.media.imageio.stream.RawImageInputStream;
-import com.sun.media.imageio.stream.SegmentedImageInputStream;
+import com.github.jaiimageio.stream.RawImageInputStream;
+import com.github.jaiimageio.stream.SegmentedImageInputStream;
 
 /**
  * @author Gunter Zeilinger <gunterze@gmail.com>


### PR DESCRIPTION
Avoids GPL-incompatible JPEG 2000 dependency by using the forked [jai-imageio-core](https://github.com/jai-imageio/jai-imageio-core) instead of jai_imageio 1.1.

See jai-imageio/jai-imageio-core#15 and
jai-imageio/jai-imageio-core#4
for relevant discussion with dcm4che2
user @RemiSgt

Note that jai-imageio-core renamed com.sun.media.imageio
to com.github.jaiimageio - hence changed import statements.

The tests pass, but I was unable to build it correctly (before changing this) as Maven fails with:

```
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running org.dcm4che2.imageioimpl.plugins.dcm.DicomImageWriterTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.719 sec
Running org.dcm4che2.imageioimpl.plugins.dcm.DicomImageReaderTest
Testing image /imgconsistency/mlut_01.dcm
Testing image /imgconsistency/mlut_02.dcm
Testing image /imgconsistency/mlut_03.dcm
Testing image /imgconsistency/mlut_04.dcm
Testing image /imgconsistency/mlut_05.dcm
Testing image /imgconsistency/mlut_06.dcm
Testing image /imgconsistency/mlut_07.dcm
Testing image /imgconsistency/mlut_08.dcm
Testing image /imgconsistency/mlut_09.dcm
Testing image /imgconsistency/mlut_10.dcm
Testing image /imgconsistency/mlut_11.dcm
Testing image /imgconsistency/mlut_12.dcm
Testing image /imgconsistency/mlut_13.dcm
Testing image /imgconsistency/mlut_14.dcm
Testing image /imgconsistency/mlut_15.dcm
Testing image /imgconsistency/mlut_16.dcm
Testing image /imgconsistency/mlut_17.dcm
Testing image /imgconsistency/mlut_18.dcm
Testing image /imgconsistency/mlut_19.dcm
Testing image /imgconsistency/vlut_01.dcm
Testing image /imgconsistency/vlut_02.dcm
Testing image /imgconsistency/vlut_03.dcm
Testing image /imgconsistency/vlut_04.dcm
Testing image /imgconsistency/vlut_05.dcm
Testing image /imgconsistency/vlut_06.dcm
Testing image /imgconsistency/vlut_07.dcm
Testing image /imgconsistency/vlut_08.dcm
Testing image /imgconsistency/vlut_09.dcm
Testing image /imgconsistency/vlut_10.dcm
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.894 sec

Results :

Tests run: 12, Failures: 0, Errors: 0, Skipped: 0

[INFO] 
[INFO] --- maven-jar-plugin:2.3:jar (default-jar) @ dcm4che-imageio ---
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 4.737 s
[INFO] Finished at: 2015-09-23T13:56:30+01:00
[INFO] Final Memory: 18M/297M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-jar-plugin:2.3:jar (default-jar) on project dcm4che-imageio: Error assembling JAR: Manifest file: /home/stain/src/dcm4che2/dcm4che-imageio/target/classes/META-INF/MANIFEST.MF does not exist. -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
```
